### PR TITLE
fix: add fixes for the updater and the match regex

### DIFF
--- a/packages/example/cypress/integration/index.spec.tsx
+++ b/packages/example/cypress/integration/index.spec.tsx
@@ -43,3 +43,24 @@ it('keeps track of hash links', () => {
   cy.get('label:contains("Available:") input').click();
   assertUrl('?available=0#hash');
 });
+
+it('should clear all params', () => {
+  cy.visit('?available=1&name=harry')
+  cy.get('button:contains("clear")').click();
+  assertUrl('')
+  assertRouterQuery({})
+});
+
+it('should clear all params while the hash remains', () => {
+  cy.visit('?available=1&name=harry#hash')
+  cy.get('button:contains("clear")').click();
+  assertUrl('#hash')
+  assertRouterQuery({})
+});
+
+it('should add query params correctly when a hash is already active', () => {
+  cy.visit('#hash')
+  cy.get('label:contains("Available:") input').click();
+  assertUrl('?available=1#hash')
+  assertRouterQuery({available: '1'});
+});

--- a/packages/example/src/pages/index.tsx
+++ b/packages/example/src/pages/index.tsx
@@ -16,7 +16,10 @@ export default function Index() {
     withDefault(BooleanParam, false)
   );
 
-  const [params, setParams] = useQueryParams({'name': StringParam, 'available': BooleanParam})
+  const [, setParams] = useQueryParams({
+    name: StringParam,
+    available: BooleanParam
+  });
 
   function onNameInputChange(event: ChangeEvent<HTMLInputElement>) {
     setName(event.target.value);
@@ -26,8 +29,8 @@ export default function Index() {
     setAvailable(event.target.checked);
   }
 
-  function onClearParams(){
-    setParams({available: undefined, name: undefined})
+  function onClearParams() {
+    setParams({available: undefined, name: undefined});
   }
 
   return (
@@ -56,8 +59,9 @@ export default function Index() {
         params:
       </p>
       <pre>{JSON.stringify(router.query, null, 2)}</pre>
-      <button onClick={onClearParams}>clear</button>
-
+      <button onClick={onClearParams} type="button">
+        clear
+      </button>
     </div>
   );
 }

--- a/packages/example/src/pages/index.tsx
+++ b/packages/example/src/pages/index.tsx
@@ -2,7 +2,8 @@ import {
   useQueryParam,
   StringParam,
   withDefault,
-  BooleanParam
+  BooleanParam,
+  useQueryParams
 } from 'next-query-params';
 import {useRouter} from 'next/router';
 import {ChangeEvent} from 'react';
@@ -15,12 +16,18 @@ export default function Index() {
     withDefault(BooleanParam, false)
   );
 
+  const [params, setParams] = useQueryParams({'name': StringParam, 'available': BooleanParam})
+
   function onNameInputChange(event: ChangeEvent<HTMLInputElement>) {
     setName(event.target.value);
   }
 
   function onAvailableInputChange(event: ChangeEvent<HTMLInputElement>) {
     setAvailable(event.target.checked);
+  }
+
+  function onClearParams(){
+    setParams({available: undefined, name: undefined})
   }
 
   return (
@@ -49,6 +56,8 @@ export default function Index() {
         params:
       </p>
       <pre>{JSON.stringify(router.query, null, 2)}</pre>
+      <button onClick={onClearParams}>clear</button>
+
     </div>
   );
 }

--- a/packages/next-query-params/package.json
+++ b/packages/next-query-params/package.json
@@ -22,7 +22,7 @@
     "start": "tsdx watch",
     "build": "tsdx build",
     "test": "echo \"No tests yet\"",
-    "lint": "eslint src && tsc",
+    "lint": "eslint src --fix && tsc",
     "prepublishOnly": "yarn test && yarn lint && yarn build && cp ../../README.md ."
   },
   "main": "dist/index.js",

--- a/packages/next-query-params/package.json
+++ b/packages/next-query-params/package.json
@@ -22,7 +22,7 @@
     "start": "tsdx watch",
     "build": "tsdx build",
     "test": "echo \"No tests yet\"",
-    "lint": "eslint src --fix && tsc",
+    "lint": "eslint src && tsc",
     "prepublishOnly": "yarn test && yarn lint && yarn build && cp ../../README.md ."
   },
   "main": "dist/index.js",

--- a/packages/next-query-params/src/NextQueryParamProvider.tsx
+++ b/packages/next-query-params/src/NextQueryParamProvider.tsx
@@ -11,7 +11,7 @@ type Props = Omit<
 
 function NextQueryParamProvider({children, ...rest}: Props) {
   const router = useRouter();
-  const match = router.asPath.match(/[^?]+/);
+  const match = router.asPath.match(/[^?|#]+/);
   const pathname = match ? match[0] : router.asPath;
 
   const location = useMemo(() => {

--- a/packages/next-query-params/src/NextQueryParamProvider.tsx
+++ b/packages/next-query-params/src/NextQueryParamProvider.tsx
@@ -39,8 +39,8 @@ function NextQueryParamProvider({children, ...rest}: Props) {
     function createUpdater(routeFn: typeof router.push) {
       return function updater({hash, search}: Location) {
         routeFn(
-          {pathname: router.pathname, query: router.query, search, hash},
-          {search, pathname, hash},
+          {pathname: router.pathname, search, hash},
+          {pathname, search, hash},
           {shallow: true, scroll: false}
         );
       };

--- a/packages/next-query-params/src/NextQueryParamProvider.tsx
+++ b/packages/next-query-params/src/NextQueryParamProvider.tsx
@@ -31,7 +31,7 @@ function NextQueryParamProvider({children, ...rest}: Props) {
       // On the server side we only need a subset of the available
       // properties of `Location`. The other ones are only necessary
       // for interactive features on the client.
-      return {search: router.asPath.replace(/[^?]+/u, '')} as Location;
+      return {search: router.asPath.replace(/[^?|#]+/u, '')} as Location;
     }
   }, [router.asPath, router.isReady]);
 

--- a/packages/next-query-params/src/NextQueryParamProvider.tsx
+++ b/packages/next-query-params/src/NextQueryParamProvider.tsx
@@ -9,9 +9,11 @@ type Props = Omit<
   'ReactRouterRoute' | 'reachHistory' | 'history' | 'location'
 >;
 
+const pathnameRegex = /[^?#]+/u;
+
 function NextQueryParamProvider({children, ...rest}: Props) {
   const router = useRouter();
-  const match = router.asPath.match(/[^?|#]+/);
+  const match = router.asPath.match(pathnameRegex);
   const pathname = match ? match[0] : router.asPath;
 
   const location = useMemo(() => {
@@ -31,7 +33,7 @@ function NextQueryParamProvider({children, ...rest}: Props) {
       // On the server side we only need a subset of the available
       // properties of `Location`. The other ones are only necessary
       // for interactive features on the client.
-      return {search: router.asPath.replace(/[^?|#]+/u, '')} as Location;
+      return {search: router.asPath.replace(pathnameRegex, '')} as Location;
     }
   }, [router.asPath, router.isReady]);
 


### PR DESCRIPTION
Hello @amannn,

Here I am again 😬. So I've noticed some more bugs which I create this PR for.

Firstly, `search` and `router.query` that were passed to the `url` parameter conflicted. When clearing the params for example, they'd remain in the `router.query` object and got basically out of sync with the `useQueryParam(s)` hook. I modified the `updater` function so that it passes only the `search`.

Furthermore, I've modified the match regex in order to also consider hashes in the `asPath` as there was still some funkyness going on when switching up and changing params.

fyi, I also tried it with a dynamic route and this works as expected.