### PR TITLE
fix: incorrect TypeScript types

### DIFF
--- a/packages/next-query-params/src/NextAdapterApp.tsx
+++ b/packages/next-query-params/src/NextAdapterApp.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import {usePathname, useRouter, useSearchParams} from 'next/navigation';
-import {memo, ReactElement, useMemo} from 'react';
+import {ReactElement, useMemo} from 'react';
 import {PartialLocation, QueryParamAdapter} from 'use-query-params';
 
 type Props = {
@@ -42,4 +42,4 @@ function NextAdapter({children}: Props) {
   return children(adapter);
 }
 
-export default memo(NextAdapter);
+export default NextAdapter;

--- a/packages/next-query-params/src/NextAdapterPages.tsx
+++ b/packages/next-query-params/src/NextAdapterPages.tsx
@@ -1,5 +1,5 @@
 import {useRouter} from 'next/router';
-import {memo, ReactElement, useMemo} from 'react';
+import {ReactElement, useMemo} from 'react';
 import {PartialLocation, QueryParamAdapter} from 'use-query-params';
 
 const pathnameRegex = /[^?#]+/u;
@@ -59,4 +59,4 @@ function NextAdapter({children, shallow = true}: Props) {
   return children(adapter);
 }
 
-export default memo(NextAdapter);
+export default NextAdapter;


### PR DESCRIPTION
by removing `memo(Adapter)`

[discussion at https://github.com/amannn/next-query-params/issues/32](https://github.com/amannn/next-query-params/issues/32#issuecomment-1597185753)

Fixes #32