### PR TITLE
fix: Ensure router is ready before accessing asPath

### DIFF
--- a/packages/next-query-params/src/NextAdapterPages.tsx
+++ b/packages/next-query-params/src/NextAdapterPages.tsx
@@ -11,7 +11,7 @@ type Props = {
 
 export default function NextAdapterPages({children, shallow = true}: Props) {
   const router = useRouter();
-  const match = router.asPath.match(pathnameRegex);
+  const match = router.isReady ? router.asPath.match(pathnameRegex) : null;
   const pathname = match ? match[0] : router.asPath;
 
   const location = useMemo(() => {


### PR DESCRIPTION
This is a blocker for us at the moment. @amannn would you be able to merge this fix and create a release please 🙏🏼 

Closes https://github.com/amannn/next-query-params/issues/40